### PR TITLE
Fix duplicate keyword and align Gemini config

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -315,26 +315,8 @@ def get_gemini_command_response(natural_language_input: str, model_name: str, ap
         # Initialize the Gemini client
         client = genai.Client(api_key=api_key)
 
-        # Create the GenerationConfig object including system_instruction and candidate_count
-        # as per subtask instructions 5 and 6.
-        # This assumes 'system_instruction' is a valid parameter for GenerationConfig.
-        merged_config = genai.types.GenerationConfig(
-            candidate_count=1,
-            # system_instruction=gemini_config.SYSTEM_INSTRUCTION # This is not a standard field.
-            # The prompt is specific: "system_instruction should be passed within a genai.types.GenerateContentConfig object"
-            # "which is then passed to the config parameter of client.models.generate_content()"
-            # This implies system_instruction is a field of GenerationConfig.
-            # If this causes an error, the prompt's interpretation of the SDK is flawed.
-            # For now, I will adhere strictly.
-            # Looking at google-python-aiplatform documentation, or google-generativeai docs,
-            # system_instruction is NOT part of GenerationConfig. It's a separate parameter for the model or generate_content method.
-            # Example: client.generate_content(..., system_instruction=..., generation_config=...)
-            # Given the strictness of the prompt, I will try to pass it as specified,
-            # but if there's a `TypeError` later, this is the likely cause.
-            # The prompt might be using "config" and "GenerationConfig" somewhat interchangeably with "parameters for the call".
-
-            # As per new instructions, system_instruction and candidate_count BOTH go into GenerationConfig.
-            candidate_count=1,
+        # Create the GenerateContentConfig object with the system instruction.
+        merged_config = genai.types.GenerateContentConfig(
             system_instruction=gemini_config.SYSTEM_INSTRUCTION
         )
 
@@ -343,7 +325,7 @@ def get_gemini_command_response(natural_language_input: str, model_name: str, ap
         response = client.models.generate_content(
             model=model_name, # Pass model_name directly
             contents=[natural_language_input],
-            config=merged_config # Pass the GenerationConfig object to the 'config' parameter
+            config=merged_config  # Pass the GenerateContentConfig object to the 'config' parameter
         )
 
         if response.candidates:


### PR DESCRIPTION
## Summary
- update Gemini config call to use `GenerateContentConfig`
- remove duplicate `candidate_count` parameter causing `SyntaxError`

## Testing
- `python -m py_compile commands.py main.py data.py run.py`


------
https://chatgpt.com/codex/tasks/task_e_684e41c7496883248a216eac42f39abb